### PR TITLE
Fix #52: Remove BOM if exists

### DIFF
--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -209,6 +209,11 @@ class GithubRepository implements RepositoryInterface
         }
         $json = $response->getBody(true);
 
+        // remove BOM if exists
+        if (substr($json, 0, 3) == "\xef\xbb\xbf") {
+            $json = substr($json, 3);
+        }
+
         // for package.json, remove dependencies (see the case of Modernizr)
         if (isset($depPackageJsonURL)) {
             $array = json_decode($json, true);

--- a/tests/Bowerphp/Test/Repository/GithubRepositoryTest.php
+++ b/tests/Bowerphp/Test/Repository/GithubRepositoryTest.php
@@ -47,6 +47,29 @@ class GithubRepositoryTest extends TestCase
         $this->assertEquals($bowerJson, $this->repository->getBower('master', false, 'https://raw.githubusercontent.com/components/jquery'));
     }
 
+    public function testGetBowerWithByteMarkOrder()
+    {
+        $request = Mockery::mock('Guzzle\Http\Message\RequestInterface');
+        $response = Mockery::mock('Guzzle\Http\Message\Response');
+
+        $bowerJson = '{"name": "jquery", "version": "2.0.3", "main": "jquery.js"}';
+        $bowerJsonWithBOM = "\xef\xbb\xbf".$bowerJson;
+        $url = 'https://raw.githubusercontent.com/components/jquery/master/bower.json';
+
+        $this->httpClient
+            ->shouldReceive('get')->with($url)->andReturn($request)
+        ;
+        $request
+            ->shouldReceive('send')->andReturn($response)
+        ;
+        $response
+            ->shouldReceive('getEffectiveUrl')->andReturn($url)
+            ->shouldReceive('getBody')->andReturn($bowerJsonWithBOM)
+        ;
+
+        $this->assertEquals($bowerJson, $this->repository->getBower());
+    }
+
     /**
      * @expectedException Guzzle\Http\Exception\BadResponseException
      */


### PR DESCRIPTION
This checks if the returned JSON has Byte Order Mark, and removes it.
