### PR TITLE
Update command: install package if not present yet

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -147,7 +147,7 @@ class Bowerphp
     {
         $installer = $this->installer;
         if (!$this->isPackageInstalled($package)) {
-            throw new RuntimeException(sprintf('Package %s is not installed.', $package->getName()));
+            $this->installPackage($package, $installer);
         }
         if (is_null($package->getRequiredVersion())) {
             $decode = $this->config->getBowerFileContent();


### PR DESCRIPTION
**tl;dr;**

`bowerphp update` = `composer update` 

---

My goal is to have `bower.json` only a install dependencies from it by single command (the way composer does it).

In composer, where update command is run, all missing packages are installed.
It makes sense, not to force user manually install every package, that is not there yet.  

Maybe I didn't find the correct way to do this, so feel free to correct me :).
