### PR TITLE
Installer: package version is optional

### DIFF
--- a/src/Bowerphp/Installer/Installer.php
+++ b/src/Bowerphp/Installer/Installer.php
@@ -138,7 +138,7 @@ class Installer implements InstallerInterface
                 if (is_null($bower)) {
                     throw new RuntimeException(sprintf('Invalid content in .bower.json for package %s.', $packageDirectory));
                 }
-                $packages[] = new Package($bower['name'], null, $bower['version'], isset($bower['dependencies']) ? $bower['dependencies'] : null);
+                $packages[] = new Package($bower['name'], null, isset($bower['version']) ? $bower['version'] : null, isset($bower['dependencies']) ? $bower['dependencies'] : null);
             }
         }
 


### PR DESCRIPTION
I just installed package without version (which causes this bug) and I checked, that version is really optional: http://bower.io/docs/creating-packages/
