### PR TITLE
Fixed performance when search packages.

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -16,6 +16,7 @@ use Bowerphp\Installer\InstallerInterface;
 use Bowerphp\Output\BowerphpConsoleOutput;
 use Bowerphp\Package\Package;
 use Bowerphp\Package\PackageInterface;
+use Bowerphp\Package\Search;
 use Bowerphp\Repository\RepositoryInterface;
 use Bowerphp\Util\Filesystem;
 use Guzzle\Http\ClientInterface;
@@ -97,7 +98,7 @@ class Bowerphp
 
         $this->output->writelnInstalledPackage($package);
 
-        $tmpFileName = $this->config->getCacheDir() . '/tmp/' . $package->getName();
+        $tmpFileName = $this->config->getCacheDir().'/tmp/'.$package->getName();
         $this->filesystem->write($tmpFileName, $file);
 
         $installer->install($package);
@@ -175,7 +176,7 @@ class Bowerphp
         // get release archive from repository
         $file = $this->repository->getRelease();
 
-        $tmpFileName = $this->config->getCacheDir() . '/tmp/' . $package->getName();
+        $tmpFileName = $this->config->getCacheDir().'/tmp/'.$package->getName();
         $this->filesystem->write($tmpFileName, $file);
 
         $installer->update($package);
@@ -215,7 +216,7 @@ class Bowerphp
     {
         // look for package in bower
         try {
-            $request = $this->httpClient->get($this->config->getBasePackagesUrl() . urlencode($package->getName()));
+            $request = $this->httpClient->get($this->config->getBasePackagesUrl().urlencode($package->getName()));
             $response = $request->send();
         } catch (RequestException $e) {
             throw new RuntimeException(sprintf('Cannot download package %s (%s).', $package->getName(), $e->getMessage()));
@@ -274,22 +275,9 @@ class Bowerphp
      */
     public function searchPackages($name)
     {
-        try {
-            $url = $this->config->getAllPackagesUrl();
-            $request = $this->httpClient->get($url);
-            $response = $request->send();
-        } catch (RequestException $e) {
-            throw new RuntimeException(sprintf('Cannot get package list from %s.', $url));
-        }
-        $decode = json_decode($response->getBody(true), true);
-        $return = array();
-        foreach ($decode as $pkg) {
-            if (false !== strpos($pkg['name'], $name)) {
-                $return[] = $pkg['name'];
-            }
-        }
+        $search = new Search($this->config, $this->httpClient);
 
-        return $return;
+        return $search->package($name);
     }
 
     /**
@@ -312,7 +300,7 @@ class Bowerphp
      */
     public function isPackageInstalled(PackageInterface $package)
     {
-        return $this->filesystem->exists($this->config->getInstallDir() . '/' . $package->getName() . '/.bower.json');
+        return $this->filesystem->exists($this->config->getInstallDir().'/'.$package->getName().'/.bower.json');
     }
 
     /**
@@ -365,7 +353,7 @@ class Bowerphp
     {
         // look for package in bower
         try {
-            $request = $this->httpClient->get($this->config->getBasePackagesUrl() . $package->getName());
+            $request = $this->httpClient->get($this->config->getBasePackagesUrl().$package->getName());
             $response = $request->send();
         } catch (RequestException $e) {
             throw new RuntimeException(sprintf('Cannot download package %s (%s).', $package->getName(), $e->getMessage()));

--- a/src/Bowerphp/Command/Command.php
+++ b/src/Bowerphp/Command/Command.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Bowerphp.
  *
@@ -8,7 +7,6 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace Bowerphp\Command;
 
 use Guzzle\Http\ClientInterface;
@@ -37,12 +35,11 @@ abstract class Command extends BaseCommand
             $logger = function ($message) use ($output) {
                 $finfo = new \finfo(FILEINFO_MIME);
                 $msg =  (substr($finfo->buffer($message), 0, 4) == 'text') ? $message : '(binary string)';
-                $output->writeln('<info>Guzzle</info> ' . $msg);
+                $output->writeln('<info>Guzzle</info> '.$msg);
             };
             $logAdapter = new ClosureLogAdapter($logger);
             $logPlugin = new LogPlugin($logAdapter, MessageFormatter::DEBUG_FORMAT);
             $client->addSubscriber($logPlugin);
         }
     }
-
 }

--- a/src/Bowerphp/Command/HomeCommand.php
+++ b/src/Bowerphp/Command/HomeCommand.php
@@ -63,7 +63,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 
@@ -119,5 +119,4 @@ EOT
 
         return trim($xdgOpen->getOutput());
     }
-
 }

--- a/src/Bowerphp/Command/InfoCommand.php
+++ b/src/Bowerphp/Command/InfoCommand.php
@@ -64,7 +64,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 

--- a/src/Bowerphp/Command/InitCommand.php
+++ b/src/Bowerphp/Command/InitCommand.php
@@ -59,7 +59,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 

--- a/src/Bowerphp/Command/InstallCommand.php
+++ b/src/Bowerphp/Command/InstallCommand.php
@@ -77,7 +77,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-            'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+            'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 
@@ -103,7 +103,7 @@ EOT
         } catch (\RuntimeException $e) {
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             if ($e->getCode() == GithubRepository::VERSION_NOT_FOUND && !empty($package)) {
-                $output->writeln(sprintf('Available versions: %s', implode(', ' , $bowerphp->getPackageInfo($package, 'versions'))));
+                $output->writeln(sprintf('Available versions: %s', implode(', ', $bowerphp->getPackageInfo($package, 'versions'))));
             }
 
             return $e->getCode();
@@ -111,5 +111,4 @@ EOT
 
         $output->writeln('');
     }
-
 }

--- a/src/Bowerphp/Command/LookupCommand.php
+++ b/src/Bowerphp/Command/LookupCommand.php
@@ -62,7 +62,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 
@@ -79,7 +79,5 @@ EOT
         $bower         = $bowerphp->getPackageInfo($package, 'original_url');
 
         $consoleOutput->writelnSearchOrLookup($bower['name'], $bower['url']);
-
     }
-
 }

--- a/src/Bowerphp/Command/SearchCommand.php
+++ b/src/Bowerphp/Command/SearchCommand.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Bowerphp.
  *
@@ -8,13 +7,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace Bowerphp\Command;
 
 use Bowerphp\Bowerphp;
 use Bowerphp\Config\Config;
 use Bowerphp\Output\BowerphpConsoleOutput;
-use Bowerphp\Package\Package;
 use Bowerphp\Repository\GithubRepository;
 use Bowerphp\Util\Filesystem;
 use Doctrine\Common\Cache\FilesystemCache;
@@ -22,8 +19,8 @@ use Guzzle\Cache\DoctrineCacheAdapter;
 use Guzzle\Http\Client;
 use Guzzle\Plugin\Cache\CachePlugin;
 use Guzzle\Plugin\Cache\DefaultCacheStorage;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -45,8 +42,7 @@ The <info>%command.name%</info> command searches for a package by name.
 
   <info>php %command.full_name% name</info>
 EOT
-            )
-        ;
+            );
     }
 
     /**
@@ -62,7 +58,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+            'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 
@@ -70,19 +66,15 @@ EOT
 
         $consoleOutput = new BowerphpConsoleOutput($output);
         $bowerphp = new Bowerphp($config, $filesystem, $httpClient, new GithubRepository(), $consoleOutput);
-        $packageNames  =  $bowerphp->searchPackages($name);
+        $packages = $bowerphp->searchPackages($name);
 
-        if (count($packageNames) === 0) {
+        if (empty($packages)) {
             $output->writeln('No results.');
         } else {
-            $output->writeln('Search results:');
-            $output->writeln('');
-            foreach ($packageNames as $packageName) {
-                $package = new Package($packageName);
-                $bower = $bowerphp->getPackageInfo($package, 'original_url');
-
-                $consoleOutput->writelnSearchOrLookup($bower['name'], $bower['url'], 4);
-            }
+            $output->writeln('Search results:'.PHP_EOL);
+            array_walk($packages, function ($package) use ($consoleOutput) {
+                $consoleOutput->writelnSearchOrLookup($package['name'], $package['url'], 4);
+            });
         }
     }
 }

--- a/src/Bowerphp/Command/UninstallCommand.php
+++ b/src/Bowerphp/Command/UninstallCommand.php
@@ -64,7 +64,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+           'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 

--- a/src/Bowerphp/Command/UpdateCommand.php
+++ b/src/Bowerphp/Command/UpdateCommand.php
@@ -71,7 +71,7 @@ EOT
 
         // http cache
         $cachePlugin = new CachePlugin(array(
-            'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400)
+            'storage' => new DefaultCacheStorage(new DoctrineCacheAdapter(new FilesystemCache($config->getCacheDir())), 'bowerphp', 86400),
         ));
         $httpClient->addSubscriber($cachePlugin);
 

--- a/src/Bowerphp/Compiler.php
+++ b/src/Bowerphp/Compiler.php
@@ -220,7 +220,7 @@ EOF;
             $stub .= "define('BOWERPHP_DEV_WARNING_TIME', $warningTime);\n";
         }
 
-        return $stub . <<<'EOF'
+        return $stub.<<<'EOF'
 require 'phar://bowerphp.phar/bin/bowerphp';
 
 __HALT_COMPILER();

--- a/src/Bowerphp/Config/Config.php
+++ b/src/Bowerphp/Config/Config.php
@@ -36,9 +36,9 @@ class Config implements ConfigInterface
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
-        $this->cacheDir   = getenv('HOME') . '/.cache/bowerphp';
-        $this->installDir = getcwd() . '/bower_components';
-        $rc               = getcwd() . '/.bowerrc';
+        $this->cacheDir   = getenv('HOME').'/.cache/bowerphp';
+        $this->installDir = getcwd().'/bower_components';
+        $rc               = getcwd().'/.bowerrc';
 
         if ($this->filesystem->exists($rc)) {
             $json = json_decode($this->filesystem->read($rc), true);
@@ -46,7 +46,7 @@ class Config implements ConfigInterface
                 throw new RuntimeException('Invalid .bowerrc file.');
             }
             if (isset($json['directory'])) {
-                $this->installDir = getcwd() . '/' . $json['directory'];
+                $this->installDir = getcwd().'/'.$json['directory'];
             }
             if (isset($json['storage']) && isset($json['storage']['packages'])) {
                 $this->cacheDir = $json['storage']['packages'];
@@ -107,7 +107,7 @@ class Config implements ConfigInterface
      */
     public function initBowerJsonFile(array $params)
     {
-        $file = getcwd() . '/' . $this->stdBowerFileName;
+        $file = getcwd().'/'.$this->stdBowerFileName;
         $json = Json::encode($this->createAClearBowerFile($params));
 
         return $this->filesystem->write($file, $json);
@@ -124,7 +124,7 @@ class Config implements ConfigInterface
 
         $decode = $this->getBowerFileContent();
         $decode['dependencies'][$package->getName()] = $package->getRequiredVersion();
-        $file = getcwd() . '/' . $this->stdBowerFileName;
+        $file = getcwd().'/'.$this->stdBowerFileName;
         $json = Json::encode($decode);
 
         return $this->filesystem->write($file, $json);
@@ -136,7 +136,7 @@ class Config implements ConfigInterface
     public function updateBowerJsonFile2(array $old, array $new)
     {
         $json = Json::encode(array_merge($old, $new));
-        $file = getcwd() . '/' . $this->stdBowerFileName;
+        $file = getcwd().'/'.$this->stdBowerFileName;
 
         return $this->filesystem->write($file, $json);
     }
@@ -146,10 +146,10 @@ class Config implements ConfigInterface
      */
     public function getBowerFileContent()
     {
-        if (!$this->filesystem->exists(getcwd() . '/' . $this->stdBowerFileName)) {
-            throw new RuntimeException('No ' . $this->stdBowerFileName . ' found. You can run "init" command to create it.');
+        if (!$this->filesystem->exists(getcwd().'/'.$this->stdBowerFileName)) {
+            throw new RuntimeException('No '.$this->stdBowerFileName.' found. You can run "init" command to create it.');
         }
-        $bowerJson = $this->filesystem->read(getcwd() . '/' . $this->stdBowerFileName);
+        $bowerJson = $this->filesystem->read(getcwd().'/'.$this->stdBowerFileName);
         if (empty($bowerJson) || !is_array($decode = json_decode($bowerJson, true))) {
             throw new RuntimeException(sprintf('Malformed JSON %s.', $bowerJson));
         }
@@ -162,7 +162,7 @@ class Config implements ConfigInterface
      */
     public function getPackageBowerFileContent(PackageInterface $package)
     {
-        $file = $this->getInstallDir() . '/' . $package->getName() . '/.bower.json';
+        $file = $this->getInstallDir().'/'.$package->getName().'/.bower.json';
         if (!$this->filesystem->exists($file)) {
             throw new RuntimeException(sprintf('Could not find .bower.json file for package %s.', $package->getName()));
         }
@@ -180,7 +180,7 @@ class Config implements ConfigInterface
      */
     public function bowerFileExists()
     {
-        return $this->filesystem->exists(getcwd() . '/' . $this->stdBowerFileName);
+        return $this->filesystem->exists(getcwd().'/'.$this->stdBowerFileName);
     }
 
     /**

--- a/src/Bowerphp/Console/Application.php
+++ b/src/Bowerphp/Console/Application.php
@@ -85,7 +85,7 @@ class Application extends BaseApplication
      */
     public function getHelp()
     {
-        return self::$logo . parent::getHelp();
+        return self::$logo.parent::getHelp();
     }
 
     /**

--- a/src/Bowerphp/Installer/Installer.php
+++ b/src/Bowerphp/Installer/Installer.php
@@ -40,7 +40,7 @@ class Installer implements InstallerInterface
      */
     public function install(PackageInterface $package)
     {
-        $tmpFileName = $this->config->getCacheDir() . '/tmp/' . $package->getName();
+        $tmpFileName = $this->config->getCacheDir().'/tmp/'.$package->getName();
         if ($this->zipArchive->open($tmpFileName) !== true) {
             throw new RuntimeException(sprintf('Unable to open zip file %s.', $tmpFileName));
         }
@@ -49,7 +49,7 @@ class Installer implements InstallerInterface
         $files = $this->filterZipFiles($this->zipArchive, isset($info['ignore']) ? $info['ignore'] : array());
         foreach ($files as $i => $file) {
             $stat = $this->zipArchive->statIndex($i);
-            $fileName = $this->config->getInstallDir() . '/' . str_replace($dirName, $package->getName(), $file);
+            $fileName = $this->config->getInstallDir().'/'.str_replace($dirName, $package->getName(), $file);
             if (substr($fileName, -1) != '/') {
                 $fileContent = $this->zipArchive->getStream($file);
                 $this->filesystem->write($fileName, $fileContent);
@@ -59,7 +59,7 @@ class Installer implements InstallerInterface
         // adjust timestamp for directories
         foreach ($files as $i => $file) {
             $stat = $this->zipArchive->statIndex($i);
-            $fileName = $this->config->getInstallDir() . '/' . str_replace($dirName, $package->getName(), $file);
+            $fileName = $this->config->getInstallDir().'/'.str_replace($dirName, $package->getName(), $file);
             if (is_dir($fileName) && substr($fileName, -1) == '/') {
                 $this->filesystem->touch($fileName, $stat['mtime']);
             }
@@ -69,7 +69,7 @@ class Installer implements InstallerInterface
         // create .bower.json metadata file
         // XXX we still need to add some other info...
         $dotBowerJson = Json::encode($package->getInfo());
-        $this->filesystem->write($this->config->getInstallDir() . '/' . $package->getName() . '/.bower.json', $dotBowerJson);
+        $this->filesystem->write($this->config->getInstallDir().'/'.$package->getName().'/.bower.json', $dotBowerJson);
     }
 
     /**
@@ -78,7 +78,7 @@ class Installer implements InstallerInterface
     public function update(PackageInterface $package)
     {
         // install files
-        $tmpFileName = $this->config->getCacheDir() . '/tmp/' . $package->getName();
+        $tmpFileName = $this->config->getCacheDir().'/tmp/'.$package->getName();
         if ($this->zipArchive->open($tmpFileName) !== true) {
             throw new RuntimeException(sprintf('Unable to open zip file %s.', $tmpFileName));
         }
@@ -87,7 +87,7 @@ class Installer implements InstallerInterface
         $files = $this->filterZipFiles($this->zipArchive, isset($info['ignore']) ? $info['ignore'] : array());
         foreach ($files as $i => $file) {
             $stat = $this->zipArchive->statIndex($i);
-            $fileName = $this->config->getInstallDir() . '/' . str_replace($dirName, $package->getName(), $file);
+            $fileName = $this->config->getInstallDir().'/'.str_replace($dirName, $package->getName(), $file);
             if (substr($fileName, -1) != '/') {
                 $fileContent = $this->zipArchive->getStream($file);
                 $this->filesystem->write($fileName, $fileContent);
@@ -97,7 +97,7 @@ class Installer implements InstallerInterface
         // adjust timestamp for directories
         foreach ($files as $i => $file) {
             $stat = $this->zipArchive->statIndex($i);
-            $fileName = $this->config->getInstallDir() . '/' . str_replace($dirName, $package->getName(), $file);
+            $fileName = $this->config->getInstallDir().'/'.str_replace($dirName, $package->getName(), $file);
             if (substr($fileName, -1) == '/' && is_dir($fileName)) {
                 $this->filesystem->touch($fileName, $stat['mtime']);
             }
@@ -108,7 +108,7 @@ class Installer implements InstallerInterface
         // XXX we still need to add some other info...
         $dotBowerContent = array_merge($package->getInfo(), array('version' => $package->getRequiredVersion()));
         $dotBowerJson = Json::encode($dotBowerContent);
-        $this->filesystem->write($this->config->getInstallDir() . '/' . $package->getName() . '/.bower.json', $dotBowerJson);
+        $this->filesystem->write($this->config->getInstallDir().'/'.$package->getName().'/.bower.json', $dotBowerJson);
     }
 
     /**
@@ -116,7 +116,7 @@ class Installer implements InstallerInterface
      */
     public function uninstall(PackageInterface $package)
     {
-        $this->removeDir($this->config->getInstallDir() . '/' . $package->getName());
+        $this->removeDir($this->config->getInstallDir().'/'.$package->getName());
     }
 
     /**
@@ -132,8 +132,8 @@ class Installer implements InstallerInterface
         $directories = $finder->directories()->in($this->config->getInstallDir());
 
         foreach ($directories as $packageDirectory) {
-            if ($this->filesystem->exists($packageDirectory . '/.bower.json')) {
-                $bowerJson = $this->filesystem->read($packageDirectory . '/.bower.json');
+            if ($this->filesystem->exists($packageDirectory.'/.bower.json')) {
+                $bowerJson = $this->filesystem->read($packageDirectory.'/.bower.json');
                 $bower = json_decode($bowerJson, true);
                 if (is_null($bower)) {
                     throw new RuntimeException(sprintf('Invalid content in .bower.json for package %s.', $packageDirectory));
@@ -211,10 +211,10 @@ class Installer implements InstallerInterface
             if (strpos($pattern, '**') !== false) {
                 $pattern = str_replace('**', '*', $pattern);
                 if (substr($pattern, 0, 1) == '/') {
-                    $vName = '/'. $vName;
+                    $vName = '/'.$vName;
                 }
                 if (substr($vName, 0, 1) == '.') {
-                    $vName = '/'. $vName;
+                    $vName = '/'.$vName;
                 }
                 if (fnmatch($pattern, $vName, FNM_PATHNAME)) {
                     return true;
@@ -224,22 +224,22 @@ class Installer implements InstallerInterface
                     $pattern = substr($pattern, 1); // remove possible starting slash
                 }
                 $escPattern = str_replace(array('.', '*'), array('\.', '.*'), $pattern);
-                if (preg_match('#^' . $escPattern . '#', $vName) > 0) {
+                if (preg_match('#^'.$escPattern.'#', $vName) > 0) {
                     return true;
                 }
             } elseif (strpos($pattern, '/') === false) { // no slash
                 $escPattern = str_replace(array('.', '*'), array('\.', '.*'), $pattern);
-                if (preg_match('#^' . $escPattern . '#', $vName) > 0) {
+                if (preg_match('#^'.$escPattern.'#', $vName) > 0) {
                     return true;
                 }
             } elseif (substr($pattern, 0, 1) == '/') {    // starting slash
                 $escPattern = str_replace(array('.', '*'), array('\.', '.*'), $pattern);
-                if (preg_match('#^' . $escPattern . '#', '/' . $vName) > 0) {
+                if (preg_match('#^'.$escPattern.'#', '/'.$vName) > 0) {
                     return true;
                 }
             } else {
                 $escPattern = str_replace(array('.', '*'), array('\.', '.*'), $pattern);
-                if (preg_match('#^' . $escPattern . '#', $vName) > 0) {
+                if (preg_match('#^'.$escPattern.'#', $vName) > 0) {
                     return true;
                 }
             }

--- a/src/Bowerphp/Output/BowerphpConsoleOutput.php
+++ b/src/Bowerphp/Output/BowerphpConsoleOutput.php
@@ -36,7 +36,7 @@ class BowerphpConsoleOutput
     public function writelnInfoPackage(PackageInterface $package)
     {
         $this->output->writeln(sprintf('bower <info>%s</info>',
-            str_pad($package->getName() . '#' . $package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT)
+            str_pad($package->getName().'#'.$package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT)
         ));
     }
 
@@ -48,7 +48,7 @@ class BowerphpConsoleOutput
     public function writelnInstalledPackage(PackageInterface $package)
     {
         $this->output->writeln(sprintf('bower <info>%s</info> <fg=cyan>%s</fg=cyan>',
-            str_pad($package->getName() . '#' . $package->getVersion(), 21, ' ', STR_PAD_RIGHT),
+            str_pad($package->getName().'#'.$package->getVersion(), 21, ' ', STR_PAD_RIGHT),
             str_pad('install', 10, ' ', STR_PAD_LEFT)
         ));
     }
@@ -116,7 +116,7 @@ class BowerphpConsoleOutput
     public function writelnUpdatingPackage(PackageInterface $package)
     {
         $this->output->writeln(sprintf('bower <info>%s</info> <fg=cyan>%s</fg=cyan>',
-            str_pad($package->getName() . '#' . $package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT),
+            str_pad($package->getName().'#'.$package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT),
             str_pad('install', 10, ' ', STR_PAD_LEFT)
         ));
     }

--- a/src/Bowerphp/Package/Search.php
+++ b/src/Bowerphp/Package/Search.php
@@ -1,0 +1,39 @@
+<?php
+namespace Bowerphp\Package;
+
+use Bowerphp\Config\ConfigInterface;
+use Guzzle\Http\ClientInterface;
+use Guzzle\Http\Exception\RequestException;
+use RuntimeException;
+
+class Search
+{
+    private $config;
+    private $httpClient;
+
+    public function __construct(ConfigInterface $config, ClientInterface $httpClient)
+    {
+        $this->config = $config;
+        $this->httpClient = $httpClient;
+    }
+
+    public function package($name)
+    {
+        try {
+            $url = $this->prepareUrl($name);
+            $request = $this->httpClient->get($url);
+            $response = $request->send();
+
+            return json_decode($response->getBody(true), true);
+        } catch (RequestException $e) {
+            throw new RuntimeException(sprintf('Cannot get package list from %s.', str_replace('/packages/', '', $this->config->getBasePackagesUrl())));
+        }
+    }
+
+    private function prepareUrl($name)
+    {
+        $baseUrl = $this->config->getBasePackagesUrl();
+
+        return $baseUrl.'search/'.$name;
+    }
+}

--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -27,7 +27,7 @@ class GithubRepository implements RepositoryInterface
     public function setUrl($url, $raw = true)
     {
         $this->originalUrl = $url;
-        $this->url         = preg_replace('/\.git$/', '', str_replace('git://', 'https://' . ($raw ? 'raw.' : ''), $this->originalUrl));
+        $this->url         = preg_replace('/\.git$/', '', str_replace('git://', 'https://'.($raw ? 'raw.' : ''), $this->originalUrl));
         $this->url         = str_replace('raw.github.com', 'raw.githubusercontent.com', $this->url);
 
         return $this;
@@ -118,7 +118,7 @@ class GithubRepository implements RepositoryInterface
         }
 
         foreach ($this->sortTags($tags) as $tag) {
-            if (fnmatch($version, $tag['name']) || fnmatch('v' . $version, $tag['name'])) {
+            if (fnmatch($version, $tag['name']) || fnmatch('v'.$version, $tag['name'])) {
                 $this->tag = $tag;
 
                 return $tag['name'];
@@ -139,7 +139,7 @@ class GithubRepository implements RepositoryInterface
      */
     public function getRelease($type = 'zip')
     {
-        $file = $this->tag[$type . 'ball_url'];
+        $file = $this->tag[$type.'ball_url'];
         try {
             $request = $this->httpClient->get($file);
             $response = $request->send();
@@ -182,7 +182,7 @@ class GithubRepository implements RepositoryInterface
      */
     private function getDepBowerJson($version)
     {
-        $depBowerJsonURL = $this->url . '/' . $version . '/bower.json';
+        $depBowerJsonURL = $this->url.'/'.$version.'/bower.json';
         try {
             $request = $this->httpClient->get($depBowerJsonURL);
             $response = $request->send();
@@ -191,7 +191,7 @@ class GithubRepository implements RepositoryInterface
         } catch (BadResponseException $e) {
             if ($e->getResponse()->getStatusCode() == 404) {
                 // fallback on package.json
-                $depPackageJsonURL = $this->url . '/' . $version . '/package.json';
+                $depPackageJsonURL = $this->url.'/'.$version.'/package.json';
                 try {
                     $request = $this->httpClient->get($depPackageJsonURL);
                     $response = $request->send();
@@ -242,20 +242,20 @@ class GithubRepository implements RepositoryInterface
         }
         $bits = explode('.', $version);
         if (substr($version, 0, 1) == '~') {
-            $version = substr($version, 1) . '*';
+            $version = substr($version, 1).'*';
         } elseif (substr($version, 0, 2) == '>=') {
             if (count($bits) == 3) {
                 array_pop($bits);
                 $version = implode('.', $bits);
-                $version = substr($version, 2) . '.*';
+                $version = substr($version, 2).'.*';
             } else {
-                $version = substr($version, 2) . '.*';
+                $version = substr($version, 2).'.*';
             }
         } else {
             if (count($bits) == 1) {
-                $version = $version . '.*.*';
+                $version = $version.'.*.*';
             } elseif (count($bits) == 2) {
-                $version = $version . '.*';
+                $version = $version.'.*';
             }
         }
 
@@ -302,7 +302,7 @@ class GithubRepository implements RepositoryInterface
                 );
                 $preRelease = $matches[2] ?: 'zzzzzz';
 
-                $tag['normal_version'] = $number . $preRelease;
+                $tag['normal_version'] = $number.$preRelease;
             } else {
                 $tag['normal_version'] = 'zzzzzz';
             }

--- a/tests/Bowerphp/Test/BowerphpTest.php
+++ b/tests/Bowerphp/Test/BowerphpTest.php
@@ -619,42 +619,28 @@ EOT;
     {
         $request = Mockery::mock('Guzzle\Http\Message\RequestInterface');
         $response = Mockery::mock('Guzzle\Http\Message\Response');
-        $packagesJson = '[{"name":"jquery"},{"name":"jquery-ui"},{"name":"less"}]';
+        $packagesJson = '[{"name":"jquery","url":"git://github.com/jquery/jquery.git"},{"name":"jquery-ui","url":"git://github.com/components/jqueryui"}]';
 
-        $this->config
-            ->shouldReceive('getAllPackagesUrl')->andReturn('http://example.com')
-        ;
-
-        $this->httpClient
-            ->shouldReceive('get')->with('http://example.com')->andReturn($request)
-        ;
-        $request
-            ->shouldReceive('send')->andReturn($response)
-        ;
-        $response
-            ->shouldReceive('getBody')->andReturn($packagesJson)
-        ;
+        $this->httpClient->shouldReceive('get')->with('http://bower.herokuapp.com/packages/search/jquery')->andReturn($request);
+        $request->shouldReceive('send')->andReturn($response);
+        $response->shouldReceive('getBody')->andReturn($packagesJson);
 
         $bowerphp = new Bowerphp($this->config, $this->filesystem, $this->httpClient, $this->repository, $this->output);
-        $this->assertEquals(array('jquery', 'jquery-ui'), $bowerphp->searchPackages('jquery'));
+        $this->assertEquals(json_decode($packagesJson, true), $bowerphp->searchPackages('jquery'));
     }
 
     /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage Cannot get package list from http://example.com.
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Cannot get package list from http://bower.herokuapp.com.
      */
     public function testSearchPackagesException()
     {
-        $this->config
-            ->shouldReceive('getAllPackagesUrl')->andReturn('http://example.com')
-        ;
+        $this->config->shouldReceive('getBasePackagesUrl')->andReturn('http://example.com');
 
-        $this->httpClient
-            ->shouldReceive('get')->with('http://example.com')->andThrow(new RequestException())
-        ;
+        $this->httpClient->shouldReceive('get')->with('http://bower.herokuapp.com/packages/search/jquery')->andThrow(new RequestException());
 
         $bowerphp = new Bowerphp($this->config, $this->filesystem, $this->httpClient, $this->repository, $this->output);
-        $bowerphp->searchPackages($this->httpClient, 'jquery');
+        $bowerphp->searchPackages('jquery');
     }
 
     public function testGetInstalledPackages()

--- a/tests/Bowerphp/Test/Command/SearchCommandTest.php
+++ b/tests/Bowerphp/Test/Command/SearchCommandTest.php
@@ -1,43 +1,47 @@
 <?php
-
 namespace Bowerphp\Test\Command;
 
-use Bowerphp\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
+use Bowerphp\Factory\CommandFactory;
+use RuntimeException;
 
 /**
  * @group functional
  */
 class SearchCommandTest extends \PHPUnit_Framework_TestCase
 {
-    public function testExecute()
+    /**
+     * @test
+     */
+    public function shouldExecute()
     {
-        $application = new Application();
-        $commandTester = new CommandTester($command = $application->get('search'));
-        $commandTester->execute(array('command' => $command->getName(), 'name' => 'smart'), array('decorated' => false));
+        //when
+        $commandTester = CommandFactory::tester('search', array('name' => 'smart'));
 
+        //then
         $this->assertRegExp('/Search results/', $commandTester->getDisplay());
         $this->assertRegExp('/jquery.smartbanner.git/', $commandTester->getDisplay());
         $this->assertRegExp('/git:/', $commandTester->getDisplay());
     }
 
-    public function testExecuteNoResults()
+    /**
+     * @test
+     */
+    public function shouldWriteNoResultWhenNoPackageFound()
     {
-        $application = new Application();
-        $commandTester = new CommandTester($command = $application->get('search'));
-        $commandTester->execute(array('command' => $command->getName(), 'name' => 'unexistant'), array('decorated' => false));
+        //when
+        $commandTester = CommandFactory::tester('search', array('name' => 'unexistant'));
 
+        //then
         $this->assertRegExp('/No results/', $commandTester->getDisplay());
     }
 
     /**
-     * @expectedException        RuntimeException
+     * @expectedException RuntimeException
      * @expectedExceptionMessage Not enough arguments.
      */
-    public function testExecuteWithoutPackage()
+    public function shouldThrowExceptionWhenNoPackagePass()
     {
-        $application = new Application();
-        $commandTester = new CommandTester($command = $application->get('search'));
-        $commandTester->execute(array(), array('decorated' => false));
+        //when
+        CommandFactory::tester('search');
     }
 }

--- a/tests/Bowerphp/Test/Package/SearchTest.php
+++ b/tests/Bowerphp/Test/Package/SearchTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace Bowerphp\Test\Package;
+
+use Bowerphp\Config\ConfigInterface;
+use Bowerphp\Package\Search;
+use Guzzle\Http\ClientInterface;
+use Guzzle\Http\Exception\RequestException;
+use Guzzle\Http\Message\RequestInterface;
+use Guzzle\Http\Message\Response;
+use Mockery;
+use PHPUnit_Framework_TestCase;
+
+class SearchTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+    /**
+     * @var Response
+     */
+    private $response;
+    /**
+     * @var ConfigInterface
+     */
+    private $config;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->httpClient = Mockery::mock('\Guzzle\Http\ClientInterface');
+        $this->request = Mockery::mock('\Guzzle\Http\Message\RequestInterface');
+        $this->response = Mockery::mock('\Guzzle\Http\Message\Response');
+        $this->request->shouldReceive('send')->andReturn($this->response);
+
+        $this->config = Mockery::mock('\Bowerphp\Config\ConfigInterface');
+        $this->config->shouldReceive('getBasePackagesUrl')->andReturn('http://bower.herokuapp.com/packages/');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSearchPackages()
+    {
+        //given
+        $packagesJson = '[{"name":"jquery","url":"git://github.com/jquery/jquery.git"},{"name":"jquery-ui","url":"git://github.com/components/jqueryui"}]';
+
+        $this->httpClient->shouldReceive('get')->with('http://bower.herokuapp.com/packages/search/jquery')->andReturn($this->request);
+        $this->response->shouldReceive('getBody')->andReturn($packagesJson);
+
+        $search = new Search($this->config, $this->httpClient);
+
+        //when
+        $packages = $search->package('jquery');
+
+        //then
+        $this->assertCount(2, $packages);
+    }
+
+    /**
+     * @test
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot get package list from http://bower.herokuapp.com.
+     */
+    public function shouldThrowExceptionWhenCanNotGetPackage()
+    {
+        //given
+        $this->httpClient->shouldReceive('get')->with('http://bower.herokuapp.com/packages/search/jquery')->andThrow(new RequestException());
+        $search = new Search($this->config, $this->httpClient);
+
+        //when
+        $search->package('jquery');
+    }
+}


### PR DESCRIPTION
In old version bower getting all items from json and looked for fitting package. 
Now use api: `http://bower.herokuapp.com/packages/search/<package>`

Profiler results:
before:
`./bowerphp search sizzle --profile`
`Memory usage: 4.7MB (peak: 58.21MB), time: 29.41s`

after:
`./bowerphp search sizzle --profile`
`Memory usage: 4.67MB (peak: 4.77MB), time: 1.01s`
