### PR TITLE
For #95 - add semver library, improve version parsing and matching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/filesystem": "~2.1",
         "symfony/process": "~2.1",
         "camspiers/json-pretty": "1.0.*",
-        "knplabs/github-api": "1.3.*"
+        "knplabs/github-api": "1.3.*",
+        "vierbergenlars/php-semver": "~3.0"
     },
     "require-dev":{
         "ext-phar": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cb2cb34fc3c476485c320bc6d1bcde43",
+    "hash": "a18dc8582db7ef022610b9428e10d5aa",
     "packages": [
         {
             "name": "camspiers/json-pretty",
@@ -454,6 +454,58 @@
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
             "time": "2014-12-02 20:19:20"
+        },
+        {
+            "name": "vierbergenlars/php-semver",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vierbergenlars/php-semver.git",
+                "reference": "4dc35f3804f3b127ad557b8b2255c03204dec951"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vierbergenlars/php-semver/zipball/4dc35f3804f3b127ad557b8b2255c03204dec951",
+                "reference": "4dc35f3804f3b127ad557b8b2255c03204dec951",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "1.1.*"
+            },
+            "bin": [
+                "bin/semver",
+                "bin/update-versions"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "vierbergenlars\\SemVer\\": "src/",
+                    "vierbergenlars\\LibJs\\": "src/"
+                },
+                "classmap": [
+                    "src/vierbergenlars/SemVer/internal.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Vierbergen",
+                    "email": "vierbergenlars@gmail.com"
+                }
+            ],
+            "description": "The Semantic Versioner for PHP",
+            "keywords": [
+                "semantic",
+                "semver",
+                "versioning"
+            ],
+            "time": "2013-12-21 17:10:13"
         }
     ],
     "packages-dev": [
@@ -1221,6 +1273,7 @@
         "mockery/mockery": 20
     },
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.2",
         "ext-zip": "*",

--- a/src/Bowerphp/Compiler.php
+++ b/src/Bowerphp/Compiler.php
@@ -92,6 +92,8 @@ class Compiler
             ->in(__DIR__ . '/../../vendor/guzzle/guzzle/src/')
             ->in(__DIR__ . '/../../vendor/camspiers/json-pretty/src/')
             ->in(__DIR__ . '/../../vendor/knplabs/github-api/lib/')
+            ->in(__DIR__ . '/../../vendor/vierbergenlars/php-semver/src/vierbergenlars/LibJs/')
+            ->in(__DIR__ . '/../../vendor/vierbergenlars/php-semver/src/vierbergenlars/SemVer/')
         ;
 
         foreach ($finder as $file) {

--- a/src/Bowerphp/Config/Config.php
+++ b/src/Bowerphp/Config/Config.php
@@ -21,14 +21,15 @@ use RuntimeException;
  */
 class Config implements ConfigInterface
 {
+
     protected $cacheDir;
     protected $installDir;
     protected $filesystem;
-    protected $basePackagesUrl     = 'http://bower.herokuapp.com/packages/';
-    protected $allPackagesUrl      = 'https://bower-component-list.herokuapp.com/';
+    protected $basePackagesUrl = 'http://bower.herokuapp.com/packages/';
+    protected $allPackagesUrl = 'https://bower-component-list.herokuapp.com/';
     protected $saveToBowerJsonFile = false;
-    protected $bowerFileNames      = array('bower.json', 'package.json');
-    protected $stdBowerFileName    = 'bower.json';
+    protected $bowerFileNames = array('bower.json', 'package.json');
+    protected $stdBowerFileName = 'bower.json';
 
     /**
      * @param Filesystem $filesystem
@@ -36,9 +37,9 @@ class Config implements ConfigInterface
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
-        $this->cacheDir   = $this->getHomeDir() . '/.cache/bowerphp';
+        $this->cacheDir = $this->getHomeDir() . '/.cache/bowerphp';
         $this->installDir = getcwd() . '/bower_components';
-        $rc               = getcwd() . '/.bowerrc';
+        $rc = getcwd() . '/.bowerrc';
 
         if ($this->filesystem->exists($rc)) {
             $json = json_decode($this->filesystem->read($rc), true);
@@ -146,7 +147,7 @@ class Config implements ConfigInterface
      */
     public function getBowerFileContent()
     {
-        if (!$this->filesystem->exists(getcwd() . '/' . $this->stdBowerFileName)) {
+        if (!$this->bowerFileExists()) {
             throw new RuntimeException('No ' . $this->stdBowerFileName . ' found. You can run "init" command to create it.');
         }
         $bowerJson = $this->filesystem->read(getcwd() . '/' . $this->stdBowerFileName);
@@ -155,6 +156,34 @@ class Config implements ConfigInterface
         }
 
         return $decode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOverridesSection()
+    {
+        if ($this->bowerFileExists()) {
+            $bowerData = $this->getBowerFileContent();
+            if ($bowerData && array_key_exists('overrides', $bowerData)) {
+                return $bowerData['overrides'];
+            }
+        }
+
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOverrideFor($packageName)
+    {
+        $overrides = $this->getOverridesSection();
+        if (array_key_exists($packageName, $overrides)) {
+            return $overrides[$packageName];
+        }
+
+        return array();
     }
 
     /**
@@ -189,13 +218,13 @@ class Config implements ConfigInterface
      */
     protected function createAClearBowerFile(array $params)
     {
-        $structure =  array(
-            'name'    => $params['name'],
+        $structure = array(
+            'name' => $params['name'],
             'authors' => array(
                 0 => 'Beelab <info@bee-lab.net>',
                 1 => $params['author'],
             ),
-            'private'      => true,
+            'private' => true,
             'dependencies' => new \StdClass(),
         );
 
@@ -222,4 +251,5 @@ class Config implements ConfigInterface
 
         return rtrim($home, '/');
     }
+
 }

--- a/src/Bowerphp/Config/ConfigInterface.php
+++ b/src/Bowerphp/Config/ConfigInterface.php
@@ -84,6 +84,21 @@ interface ConfigInterface
     public function getBowerFileContent();
 
     /**
+     * Retrieve the array of overrides optionally defined in the bower.json file.
+     * Each element's key is a package name, and contains an array of other package names
+     * and versions that should replace the dependencies found in that package's canonical bower.json.
+     * @return array The overrides section from the bower.json file, or an empty array if no overrides section is defined.
+     */
+    public function getOverridesSection();
+
+    /**
+     * Get the array of overrides defined for the specified package.
+     * @param  string $packageName The name of the package for which dependencies are being overridden.
+     * @return array  A list of dependency name => override versions to be used instead of the target package's normal dependencies.  An empty array if none are defined.
+     */
+    public function getOverrideFor($packageName);
+
+    /**
      * Get content from a packages' bower.json file
      *
      * @return array

--- a/src/Bowerphp/Repository/RepositoryInterface.php
+++ b/src/Bowerphp/Repository/RepositoryInterface.php
@@ -11,6 +11,8 @@ use Github\Client;
 interface RepositoryInterface
 {
     const VERSION_NOT_FOUND = 3;
+    const INVALID_CRITERIA = 4;
+    const INVALID_CANDIDATE = 5;
 
     /**
      * @param string  $url

--- a/tests/Bowerphp/Test/BowerphpTest.php
+++ b/tests/Bowerphp/Test/BowerphpTest.php
@@ -53,6 +53,8 @@ EOT;
             ->shouldReceive('bowerFileExists')->andReturn(false, true)
             ->shouldReceive('getBowerFileContent')->andReturn(array('name' => 'Bar'))
             ->shouldReceive('setSaveToBowerJsonFile')->with(true)
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('updateBowerJsonFile2')->with(array('name' => 'Bar'), $params)->andReturn(456)
         ;
 
@@ -110,6 +112,8 @@ EOT;
             ->shouldReceive('writelnInstalledPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
         ;
 
@@ -318,6 +322,8 @@ EOT;
             'dependencies' => array('select2' => 'https://github.com/ivaynberg/select2.git#3.5.1'),
         );
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('getBowerFileContent')->andReturn($json)
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
         ;
@@ -367,7 +373,7 @@ EOT;
 
     /**
      * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage Package notinbowerjson not found in bower.json.
+     * @expectedExceptionMessage Package notinbowerjson not found in bower.json
      */
     public function testUpdatePackageNotFoundInBowerJson()
     {
@@ -546,6 +552,8 @@ EOT;
             ->shouldReceive('writelnUpdatingPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
             ->shouldReceive('getPackageBowerFileContent')->andReturn(array('name' => 'jquery-ui', 'version' => '1.10.0'))
         ;
@@ -843,6 +851,8 @@ EOT;
             ->shouldReceive('writelnInstalledPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
         ;
 
@@ -903,6 +913,8 @@ EOT;
         ;
 
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
             ->shouldReceive('getPackageBowerFileContent')->andReturn(array('name' => 'jquery', 'version' => '1.0.0'))
             ->shouldReceive('getBowerFileContent')->andReturn(array())
@@ -1039,6 +1051,8 @@ EOT;
             ->shouldReceive('writelnUpdatingPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
             ->shouldReceive('getPackageBowerFileContent')->andReturn(array('name' => 'jquery-ui', 'version' => '1.10.0'), array('name' => 'jquery', 'version' => '2.0.1'))
         ;
@@ -1119,6 +1133,8 @@ EOT;
             ->shouldReceive('writelnUpdatingPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
             ->shouldReceive('getPackageBowerFileContent')->andReturn(array('name' => 'jquery-ui', 'version' => '1.10.0'), array('name' => 'jquery', 'version' => '2.0.1'))
         ;
@@ -1375,6 +1391,8 @@ EOT;
             ->shouldReceive('writelnInstalledPackage')
         ;
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
         ;
 

--- a/tests/Bowerphp/Test/HttpMockedTestCase.php
+++ b/tests/Bowerphp/Test/HttpMockedTestCase.php
@@ -20,6 +20,8 @@ abstract class HttpMockedTestCase extends PHPUnit_Framework_TestCase
         $this->config = Mockery::mock('Bowerphp\Config\ConfigInterface');
 
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('getBasePackagesUrl')->andReturn('http://bower.herokuapp.com/packages/')
         ;
     }

--- a/tests/Bowerphp/Test/Installer/InstallerTest.php
+++ b/tests/Bowerphp/Test/Installer/InstallerTest.php
@@ -23,6 +23,8 @@ class InstallerTest extends TestCase
         $this->installer = new Installer($this->filesystem, $this->zipArchive, $this->config);
 
         $this->config
+            ->shouldReceive('getOverridesSection')->andReturn(array())
+            ->shouldReceive('getOverrideFor')->andReturn(array())
             ->shouldReceive('getBasePackagesUrl')->andReturn('http://bower.herokuapp.com/packages/')
             ->shouldReceive('getInstallDir')->andReturn(getcwd() . '/bower_components')
             ->shouldReceive('getCacheDir')->andReturn('.')


### PR DESCRIPTION
This branch introduces a 3rd-party semver library for parsing, sorting and comparing versions and criteria expressions.  All of the relevant unit tests pass, and I've added additional tests for new or changed functionality.

There is one functional test failing, I'm not sure if it's relevant to the changes, or if my environment needs to change:
```
PHPUnit 4.1.6 by Sebastian Bergmann.

Configuration read from /home/michael/Projects/bowerphp/phpunit.xml.dist

...........................................................F...  63 / 325 ( 19%)
.............S................................................. 126 / 325 ( 38%)
............................................................... 189 / 325 ( 58%)
............................................................... 252 / 325 ( 77%)
...............................................I............... 315 / 325 ( 96%)
..........

Time: 21.25 seconds, Memory: 25.75Mb

There was 1 failure:

1) Bowerphp\Test\Command\InstallCommandTest::testExecuteInstallPackageWithDependencies
Failed asserting that 'bower jquery-ui#*          
bower jquery-ui#1.11.2         install
No bower.json found. You can run "init" command to create it.
' matches PCRE pattern "/jquery#/m".

/home/michael/Projects/bowerphp/tests/Bowerphp/Test/Command/InstallCommandTest.php:63
                                                                    
FAILURES!                                                           
Tests: 325, Assertions: 365, Failures: 1, Incomplete: 1, Skipped: 1.
```

I was able to install the packages for my real-world project.  Here's a sample bower.json for those packages:
```
{
    "name": "bower-test",
    "authors": [
        "Beelab <info@bee-lab.net>",
        "Michael Tutty <mtutty@gforgegroup.com>"
    ],
    "private": true,
    "dependencies": {
        "jquery": "~1.11",
        "jqueryui": "1.*",
        "ui-router": "0.*",
        "use-angular-translate": "2.*",
        "angular-highlightjs": "0.*",
        "angular-nvd3": "0.*",
        "tinymce-dist": "~4.1",
        "angular-ui-tinymce": "0.*",
        "angular-ga": "v0.1.0",
        "ngModal": "1.*",
        "bootstrap": "3.*",
        "bootstrap-datepicker": "1.*",
        "bootstrap-growl": "1.*",
        "bootstrap3-typeahead": "3.*",
        "bootstrap-multiselect": "0.*",
        "elusive-iconfont": "2.*",
        "lodash": "2.*",
        "sticky": "1.*",
        "tagsinput": "0.*",
        "toc": "0.*",
        "visualcaptcha.angular": "0.*"
    },
    "overrides": {
        "angular-ui-tinymce": {
            "dependencies": {
                "angular-latest": "~1.x",
                "tinymce-dist"  : "~4.1"
            }
        }
    }
}
```
You'll notice an "overrides" section - I had to implement that as well, in order to work around some non-existent repository/version pointers in some components.  This isn't the same as semver issues, but more like a badly-formed URL or a mis-spelled dependency in a lib's bower.json.