### PR TITLE
For #95, remove an unneeded var

### DIFF
--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -112,8 +112,6 @@ class GithubRepository implements RepositoryInterface
         // We're not using it because it will throw an exception on what it considers to be an
         // "invalid" candidate version, and not continue checking the rest of the candidates.
         // So, even if it's faster than this code, it's not a complete solution..
-        $bestMatch = false;
-
         $matches = array_filter(
             $sortedTags, function ($tag) use ($repoName, $criteria) {
             try {


### PR DESCRIPTION
The $bestMatch var was left over from a previous matching implementation.  After changing lines 117-129, this line should also have been removed.