### PR TITLE
Fix: Impossible to install package when there is no tags.

### DIFF
--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -17,7 +17,7 @@ use vierbergenlars\SemVer\SemVerException;
 class GithubRepository implements RepositoryInterface
 {
     protected $url;
-    protected $tag = array();
+    protected $tag = array('name' => null);
     protected $githubClient;
 
     /**

--- a/tests/Bowerphp/Test/Command/InstallCommandTest.php
+++ b/tests/Bowerphp/Test/Command/InstallCommandTest.php
@@ -3,7 +3,9 @@
 namespace Bowerphp\Test\Command;
 
 use Bowerphp\Console\Application;
+use Bowerphp\Repository\GithubRepository;
 use FilesystemIterator;
+use Github\Client;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -111,6 +113,28 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/Nothing to install/m', $commandTester->getDisplay());
 
         unlink($file);
+    }
+
+    /**
+     * This test is probably not ideal in that it will only work (meaning break if the code behavior change) as long
+     * as the jquery-address package has no tag.
+     * The first assertion is designed to make sure that the test is still valid and does it's job.
+     */
+    public function testExecuteInstallWithoutTag()
+    {
+        $githubRepo = new GithubRepository();
+        $githubRepo->setUrl('https://github.com/asual/jquery-address');
+        $githubRepo->setHttpClient(new Client());
+        //The test only make sense if the library has no git tags.
+        $this->assertEquals(array(),$githubRepo->getTags());
+
+
+        $application = new Application();
+        $commandTester = new CommandTester($command = $application->get('install'));
+        $commandTester->execute(array('command' => $command->getName(), 'package' => 'jquery-address'), array('decorated' => false));
+
+        $this->assertRegExp('/jquery-address#master/m', $commandTester->getDisplay());
+        $this->assertFileExists(getcwd() . '/bower_components/jquery-address/.bower.json');
     }
 
     public function tearDown()


### PR DESCRIPTION
The install would fail with an [ErrorException] Undefined index: name.
This was because the correct tag was return by the findPackage function
but it was not stored in the object.
I have not been able to write a test case for it so I added a todo in
the test were I think it belongs.