### PR TITLE
Debug: Making sure that a package gets save even if he is already instal...

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -96,6 +96,8 @@ class Bowerphp
 
         $package->setVersion($packageTag);
 
+        $this->updateBowerFile($package, $isDependency);
+
         // if package is already installed, match current version with latest available version
         if ($this->isPackageInstalled($package)) {
             $packageBower = $this->config->getPackageBowerFileContent($package);
@@ -112,14 +114,6 @@ class Bowerphp
         $this->cachePackage($package);
 
         $installer->install($package);
-
-        if ($this->config->isSaveToBowerJsonFile() && !$isDependency) {
-            try {
-                $this->config->updateBowerJsonFile($package);
-            } catch (RuntimeException $e) {
-                $this->output->writelnNoBowerJsonFile();
-            }
-        }
 
         $overrides = $this->config->getOverrideFor($package->getName());
         if (array_key_exists('dependencies', $overrides)) {
@@ -453,5 +447,20 @@ class Bowerphp
 
         $tmpFileName = $this->config->getCacheDir() . '/tmp/' . $package->getName();
         $this->filesystem->write($tmpFileName, $file);
+    }
+
+    /**
+     * @param PackageInterface $package
+     * @param bool $isDependency
+     */
+    private function updateBowerFile(PackageInterface $package, $isDependency = false)
+    {
+        if ($this->config->isSaveToBowerJsonFile() && !$isDependency) {
+            try {
+                $this->config->updateBowerJsonFile($package);
+            } catch (RuntimeException $e) {
+                $this->output->writelnNoBowerJsonFile();
+            }
+        }
     }
 }

--- a/tests/Bowerphp/Test/BowerphpTest.php
+++ b/tests/Bowerphp/Test/BowerphpTest.php
@@ -175,6 +175,7 @@ EOT;
 
         $this->config
             ->shouldReceive('getPackageBowerFileContent')->andReturn(array('name' => 'jquery', 'version' => '2.0.3'))
+            ->shouldReceive('isSaveToBowerJsonFile')->andReturn(false)
         ;
 
         $this->filesystem

--- a/tests/Bowerphp/Test/Command/InstallCommandTest.php
+++ b/tests/Bowerphp/Test/Command/InstallCommandTest.php
@@ -23,6 +23,61 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/jquery#2/m', $commandTester->getDisplay());
         $this->assertFileExists(getcwd() . '/bower_components/jquery/.bower.json');
         $this->assertFileExists(getcwd() . '/bower_components/jquery/src/jquery.js');
+        $this->assertFileNotExists(getcwd() . '/bower.json');
+    }
+
+    public function testExecuteAndSave()
+    {
+        $application = new Application();
+        //setup
+        $commandTester = new CommandTester($command = $application->get('init'));
+        $commandTester->execute(array('command' => $command->getName()), array('interactive' => false, 'decorated' => false));
+        //install
+        $commandTester = new CommandTester($command = $application->get('install'));
+        $commandTester->execute(array('command' => $command->getName(), 'package' => 'jquery', '--save'=> true), array('decorated' => false));
+
+        //Check that the install worked
+        $this->assertRegExp('/jquery#2/m', $commandTester->getDisplay());
+        $this->assertFileExists(getcwd() . '/bower_components/jquery/.bower.json');
+        $this->assertFileExists(getcwd() . '/bower_components/jquery/src/jquery.js');
+
+        //Check that the save worked
+        $this->assertFileExists(getcwd() . '/bower.json');
+        $bowerJsonDependencies = array("jquery"=> "*");
+        $json = json_decode(file_get_contents(getcwd() . '/bower.json'), true);
+        $this->assertArrayHasKey('dependencies', $json);
+        $this->assertEquals($bowerJsonDependencies, $json['dependencies']);
+    }
+
+    /**
+     * We need to make sure that it's possible to save a package even if he has already been installed separetly.
+     * See https://github.com/Bee-Lab/bowerphp/issues/104
+     */
+    public function testExecuteAndThenTestSave()
+    {
+        $application = new Application();
+        //setup
+        $commandTester = new CommandTester($command = $application->get('init'));
+        $commandTester->execute(array('command' => $command->getName()), array('interactive' => false, 'decorated' => false));
+        //install
+        $commandTester = new CommandTester($command = $application->get('install'));
+        $commandTester->execute(array('command' => $command->getName(), 'package' => 'jquery'), array('decorated' => false));
+
+        //Check that the install worked
+        $this->assertRegExp('/jquery#2/m', $commandTester->getDisplay());
+        $this->assertFileExists(getcwd() . '/bower_components/jquery/.bower.json');
+        $this->assertFileExists(getcwd() . '/bower_components/jquery/src/jquery.js');
+
+        //Try to save the package in the bower.json
+        $commandTester = new CommandTester($command = $application->get('install'));
+        $commandTester->execute(array('command' => $command->getName(), 'package' => 'jquery', '--save'=> true), array('decorated' => false));
+
+        //Check that the save worked
+        $this->assertFileExists(getcwd() . '/bower.json');
+        $bowerJsonDependencies = array("jquery"=> "*");
+        $json = json_decode(file_get_contents(getcwd() . '/bower.json'), true);
+        $this->assertArrayHasKey('dependencies', $json);
+        $this->assertEquals($bowerJsonDependencies, $json['dependencies']);
     }
 
     public function testExecuteVerbose()
@@ -122,6 +177,9 @@ class InstallCommandTest extends \PHPUnit_Framework_TestCase
                 $path->isFile() ? unlink($path->getPathname()) : rmdir($path->getPathname());
             }
             rmdir($dir);
+        }
+        if (file_exists(getcwd() . '/bower.json')) {
+            unlink(getcwd() . '/bower.json');
         }
     }
 }


### PR DESCRIPTION
...led

Previously if a package was already installed in the right version, saving it
in the bower.json was not possible because of an early exit.

Fix #104 