### PR TITLE
Return non-zero exit status on error

### DIFF
--- a/src/Bowerphp/Command/InstallCommand.php
+++ b/src/Bowerphp/Command/InstallCommand.php
@@ -101,7 +101,7 @@ EOT
                 $output->writeln(sprintf('Available versions: %s', implode(', ', $bowerphp->getPackageInfo($package, 'versions'))));
             }
 
-            return $e->getCode();
+            return 1;
         }
 
         $output->writeln('');

--- a/src/Bowerphp/Command/UninstallCommand.php
+++ b/src/Bowerphp/Command/UninstallCommand.php
@@ -63,7 +63,7 @@ EOT
         } catch (\RuntimeException $e) {
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
 
-            return $e->getCode();
+            return 1;
         }
 
         $output->writeln('');


### PR DESCRIPTION
Both `install` and `uninstall` commands previously used the `Exception` code as an exit status. However, most `Exception`s have never had their code assigned. This caused these commands to return the default code `0` as an exit status.

This really simple patch changes this to *always* return a `1` as exit status in case any `Exception` gets caught. This is also the default behavior for all other commands and for any uncaught `Exception`s.

Simple testcase:

```bash
$ bowerphp install invalid || echo PASS
```