### PR TITLE
Improve error messages

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -427,12 +427,12 @@ class Bowerphp
     {
         try {
             $response = $this->githubClient->getHttpClient()->get($this->config->getBasePackagesUrl() . urlencode($name));
-        } catch (RequestException $e) {
-            throw new RuntimeException(sprintf('Cannot download package %s (%s).', $name, $e->getMessage()));
+        } catch (RuntimeException $e) {
+            throw new RuntimeException(sprintf('Cannot fetch registry info for package %s from search registry (%s).', $name, $e->getMessage()));
         }
         $packageInfo = json_decode($response->getBody(true), true);
         if (!is_array($packageInfo) || empty($packageInfo['url'])) {
-            throw new RuntimeException(sprintf('Package %s has malformed json or is missing "url".', $name));
+            throw new RuntimeException(sprintf('Registry info for package %s has malformed json or is missing "url".', $name));
         }
 
         return $packageInfo;

--- a/src/Bowerphp/Config/Config.php
+++ b/src/Bowerphp/Config/Config.php
@@ -151,7 +151,7 @@ class Config implements ConfigInterface
         }
         $bowerJson = $this->filesystem->read(getcwd() . '/' . $this->stdBowerFileName);
         if (empty($bowerJson) || !is_array($decode = json_decode($bowerJson, true))) {
-            throw new RuntimeException(sprintf('Malformed JSON %s.', $bowerJson));
+            throw new RuntimeException(sprintf('Malformed JSON in %s: %s.', $this->stdBowerFileName, $bowerJson));
         }
 
         return $decode;

--- a/tests/Bowerphp/Test/BowerphpTest.php
+++ b/tests/Bowerphp/Test/BowerphpTest.php
@@ -403,7 +403,7 @@ EOT;
 
     /**
      * @expectedException        RuntimeException
-     * @expectedExceptionMessage Cannot download package jquery (error).
+     * @expectedExceptionMessage Cannot fetch registry info for package jquery from search registry (error).
      */
     public function testUpdatePackageNotFoundInRepository()
     {
@@ -441,7 +441,7 @@ EOT;
 
     /**
      * @expectedException        RuntimeException
-     * @expectedExceptionMessage Package colorbox has malformed json or is missing "url".
+     * @expectedExceptionMessage Registry info for package colorbox has malformed json or is missing "url".
      */
     public function testUpdatePackageJsonException()
     {
@@ -933,7 +933,7 @@ EOT;
 
     /**
      * @expectedException        RuntimeException
-     * @expectedExceptionMessage Package colorbox has malformed json or is missing "url".
+     * @expectedExceptionMessage Registry info for package colorbox has malformed json or is missing "url".
      */
     public function testInstallPackageJsonException()
     {
@@ -1178,7 +1178,7 @@ EOT;
 
     /**
      * @expectedException        RuntimeException
-     * @expectedExceptionMessage Package colorbox has malformed json or is missing "url".
+     * @expectedExceptionMessage Registry info for package colorbox has malformed json or is missing "url".
      */
     public function testGetPackageInfoJsonException()
     {

--- a/tests/Bowerphp/Test/Config/ConfigTest.php
+++ b/tests/Bowerphp/Test/Config/ConfigTest.php
@@ -99,7 +99,7 @@ class ConfigTest extends TestCase
 
     /**
      * @expectedException        RuntimeException
-     * @expectedExceptionMessage Malformed JSON {invalid.
+     * @expectedExceptionMessage Malformed JSON in bower.json: {invalid.
      */
     public function testGetBowerFileContentWithExceptionOnInvalidJson()
     {


### PR DESCRIPTION
Updated some of the error messages to be more readable.

Previously:

```bash
$ bowerphp install invalid
Not found
```

In this case it might be obvious, however the same error message will also be shown if either one of the packages in the bower.json fails to download. We ran into this while switching to bowerphp and taking a bower.json with several entries that previously worked.

Now:

```bash
$ bowerphp install invalid
Cannot fetch registry info for package invalid from search registry (Not found)
```