### PR TITLE
Disabled triggerDeprecationError 

### DIFF
--- a/src/Bowerphp/Console/Application.php
+++ b/src/Bowerphp/Console/Application.php
@@ -127,7 +127,7 @@ class Application extends BaseApplication
     {
         $helperSet = parent::getDefaultHelperSet();
 
-        $helperSet->set(new DialogHelper());
+        $helperSet->set(new DialogHelper(false));
 
         return $helperSet;
     }

--- a/tests/Bowerphp/Test/Command/Helper/DialogHelperTest.php
+++ b/tests/Bowerphp/Test/Command/Helper/DialogHelperTest.php
@@ -8,7 +8,7 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetQuestion()
     {
-        $helper = new DialogHelper();
+        $helper = new DialogHelper(false);
         $this->assertEquals('<info>This is a question</info> [<comment>default reply</comment>]: ', $helper->getQuestion('This is a question', 'default reply'));
         $this->assertEquals('<info>Another question</info>- ', $helper->getQuestion('Another question', null, '-'));
     }


### PR DESCRIPTION
Since smyfony/console:2.7.0: This will solve Uncaught exception 'ErrorException' DialogHelper" is deprecated since version 2.5 and will be removed in 3.0. Use "Symfony\Component\Console\Helper\QuestionHelper" instead.'