### PR TITLE
fix finding untagged packages after tagged packages

### DIFF
--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -102,6 +102,8 @@ class GithubRepository implements RepositoryInterface
 
         // edge case: package has no tags
         if (count($tags) === 0) {
+            $this->tag = ['name' => 'master'];
+            
             return 'master';
         }
 


### PR DESCRIPTION
Tag information did not set  for untagged packages and installer used
tag information of previous package.