### PR TITLE
Update dependencies only if needed is greater version

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -23,6 +23,8 @@ use Guzzle\Http\Exception\RequestException;
 use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Finder\Finder;
+use vierbergenlars\SemVer\version;
+use vierbergenlars\SemVer\expression;
 
 /**
  * Main class
@@ -476,22 +478,8 @@ class Bowerphp
      */
     public function isNeedUpdate($package)
     {
-        if (!$package->getRequiredVersion()) {
-            return false;
-        }
         $packageBower = $this->config->getPackageBowerFileContent($package);
-        $requireVersion = $package->getRequiredVersion();
-        $compare = '=';
-        preg_match('!^[^\\d]+!', $requireVersion, $matches);
-        if (!empty($matches[0])) {
-            $compare = $matches[0];
-            $requireVersion = substr($requireVersion, strlen($compare));
-            if ($compare == '~') {
-                $compare = '>';
-                $requireVersion = substr($requireVersion, 0, strrpos($requireVersion, '.'));
-            }
-        }
-
-        return version_compare($requireVersion, $packageBower['version'], $compare);
+        $semver = new version($packageBower['version']);
+        return $semver->satisfies(new expression($package->getRequiredVersion()));
     }
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -467,14 +467,14 @@ class Bowerphp
             }
         }
     }
-    
+
     /**
      * Update only if needed is greater version
      *
      * @param  PackageInterface $package
      * @return bool
      */
-    public function isNeedUpdate($package) 
+    public function isNeedUpdate($package)
     {
         if (!$package->getRequiredVersion()) {
             return false;
@@ -491,7 +491,7 @@ class Bowerphp
                 $requireVersion = substr($requireVersion, 0, strrpos($requireVersion, '.'));
             }
         }
-        
+
         return version_compare($requireVersion, $packageBower['version'], $compare);
     }
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -129,7 +129,7 @@ class Bowerphp
                 $depPackage = new Package($name, $version);
                 if (!$this->isPackageInstalled($depPackage)) {
                     $this->installPackage($depPackage, $installer, true);
-                } else {
+                } elseif($this->isNeedUpdate($depPackage)) {
                     $this->updatePackage($depPackage, $installer);
                 }
             }
@@ -204,7 +204,7 @@ class Bowerphp
                 $depPackage = new Package($name, $requiredVersion);
                 if (!$this->isPackageInstalled($depPackage)) {
                     $this->installPackage($depPackage, $installer, true);
-                } else {
+                } elseif($this->isNeedUpdate($depPackage)) {
                     $this->updatePackage($depPackage, $installer);
                 }
             }
@@ -468,4 +468,30 @@ class Bowerphp
             }
         }
     }
+    
+    /**
+     * Update only if needed is greater version
+     * 
+     * @param PackageInterface $package
+     * @return boolean
+     */
+    function isNeedUpdate($package){
+		if(!$package->getRequiredVersion()){
+			return false;
+		}
+		$packageBower = $this->config->getPackageBowerFileContent($package);
+		$requireVersion = $package->getRequiredVersion();
+        $compare = '=';
+        
+		preg_match( '!^[^\\d]+!', $requireVersion, $matches);
+		if(!empty($matches[0])){
+			$compare = $matches[0];
+			$requireVersion = substr($requireVersion, strlen($compare));
+			if($compare == '~'){
+				$compare = '>';
+				$requireVersion = substr($requireVersion, 0, strrpos($requireVersion, '.'));
+			}
+		}
+		return version_compare($requireVersion, $packageBower['version'], $compare);
+	}
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -480,6 +480,7 @@ class Bowerphp
     {
         $packageBower = $this->config->getPackageBowerFileContent($package);
         $semver = new version($packageBower['version']);
+        
         return $semver->satisfies(new expression($package->getRequiredVersion()));
     }
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -480,7 +480,7 @@ class Bowerphp
     {
         $packageBower = $this->config->getPackageBowerFileContent($package);
         $semver = new version($packageBower['version']);
-        
+
         return $semver->satisfies(new expression($package->getRequiredVersion()));
     }
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -129,7 +129,7 @@ class Bowerphp
                 $depPackage = new Package($name, $version);
                 if (!$this->isPackageInstalled($depPackage)) {
                     $this->installPackage($depPackage, $installer, true);
-                } elseif($this->isNeedUpdate($depPackage)) {
+                } elseif ($this->isNeedUpdate($depPackage)) {
                     $this->updatePackage($depPackage, $installer);
                 }
             }
@@ -204,7 +204,7 @@ class Bowerphp
                 $depPackage = new Package($name, $requiredVersion);
                 if (!$this->isPackageInstalled($depPackage)) {
                     $this->installPackage($depPackage, $installer, true);
-                } elseif($this->isNeedUpdate($depPackage)) {
+                } elseif ($this->isNeedUpdate($depPackage)) {
                     $this->updatePackage($depPackage, $installer);
                 }
             }
@@ -344,7 +344,6 @@ class Bowerphp
         try {
             $bower = $this->config->getBowerFileContent();
         } catch (RuntimeException $e) { // no bower.json file, package is extraneous
-
             return true;
         }
         if (!isset($bower['dependencies'])) {
@@ -471,27 +470,28 @@ class Bowerphp
     
     /**
      * Update only if needed is greater version
-     * 
-     * @param PackageInterface $package
-     * @return boolean
+     *
+     * @param  PackageInterface $package
+     * @return bool
      */
-    function isNeedUpdate($package){
-		if(!$package->getRequiredVersion()){
-			return false;
-		}
-		$packageBower = $this->config->getPackageBowerFileContent($package);
-		$requireVersion = $package->getRequiredVersion();
+    public function isNeedUpdate($package) 
+    {
+        if (!$package->getRequiredVersion()) {
+            return false;
+        }
+        $packageBower = $this->config->getPackageBowerFileContent($package);
+        $requireVersion = $package->getRequiredVersion();
         $compare = '=';
+        preg_match('!^[^\\d]+!', $requireVersion, $matches);
+        if (!empty($matches[0])) {
+            $compare = $matches[0];
+            $requireVersion = substr($requireVersion, strlen($compare));
+            if ($compare == '~') {
+                $compare = '>';
+                $requireVersion = substr($requireVersion, 0, strrpos($requireVersion, '.'));
+            }
+        }
         
-		preg_match( '!^[^\\d]+!', $requireVersion, $matches);
-		if(!empty($matches[0])){
-			$compare = $matches[0];
-			$requireVersion = substr($requireVersion, strlen($compare));
-			if($compare == '~'){
-				$compare = '>';
-				$requireVersion = substr($requireVersion, 0, strrpos($requireVersion, '.'));
-			}
-		}
-		return version_compare($requireVersion, $packageBower['version'], $compare);
-	}
+        return version_compare($requireVersion, $packageBower['version'], $compare);
+    }
 }

--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -481,6 +481,6 @@ class Bowerphp
         $packageBower = $this->config->getPackageBowerFileContent($package);
         $semver = new version($packageBower['version']);
 
-        return $semver->satisfies(new expression($package->getRequiredVersion()));
+        return !$semver->satisfies(new expression($package->getRequiredVersion()));
     }
 }


### PR DESCRIPTION
Updater ignored installed version of package and update all package from dependencies.
In my situation - i install jquery 2.1 version for project, then install fancybox, as result, jquery updated to version 3+, but before this, jquery alredy installed as 2.1 and fancybox need only >=1.10.

This patch solve the problem