### PR TITLE
Add support for GitHub shorthand

### DIFF
--- a/src/Bowerphp/Util/PackageNameVersionExtractor.php
+++ b/src/Bowerphp/Util/PackageNameVersionExtractor.php
@@ -46,6 +46,11 @@ class PackageNameVersionExtractor
         $name = isset($map[0]) ? $map[0] : $endpoint;
         $version = isset($map[1]) ? $map[1] : '*';
 
+        // Convert user/package shorthand to GitHub url
+        if (preg_match('/^([-_a-z0-9]+)\/([-_a-z0-9]+)$/i', $name)) {
+            $name = 'https://github.com/' . $name . '.git';
+        }
+
         return new self($name, $version);
     }
 }

--- a/tests/Bowerphp/Test/Util/PackageNameVersionExtractorTest.php
+++ b/tests/Bowerphp/Test/Util/PackageNameVersionExtractorTest.php
@@ -32,4 +32,24 @@ class PackageNameVersionExtractorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('jquery', $packageNameVersion->name);
         $this->assertEquals('1.10.2', $packageNameVersion->version);
     }
+
+    public function testReturnPackageGithubUrlFromShorthand()
+    {
+        $package = 'jquery/jquery';
+
+        $packageNameVersion = PackageNameVersionExtractor::fromString($package);
+
+        $this->assertEquals('https://github.com/jquery/jquery.git', $packageNameVersion->name);
+        $this->assertEquals('*', $packageNameVersion->version);
+    }
+
+    public function testReturnPackageGithubUrlAndVersionFromShorthand()
+    {
+        $package = 'jquery/jquery#1.10.2';
+
+        $packageNameVersion = PackageNameVersionExtractor::fromString($package);
+
+        $this->assertEquals('https://github.com/jquery/jquery.git', $packageNameVersion->name);
+        $this->assertEquals('1.10.2', $packageNameVersion->version);
+    }
 }


### PR DESCRIPTION
According to docs for [install](https://bower.io/docs/api/#install) command packages can be specified as a `user/package` shorthand, which should resolve to URL on GitHub.

This PR adds this missing feature.