### PR TITLE
Fix install dependencies for GitHub packages

### DIFF
--- a/src/Bowerphp/Installer/Installer.php
+++ b/src/Bowerphp/Installer/Installer.php
@@ -75,11 +75,12 @@ class Installer implements InstallerInterface
         }
         $this->zipArchive->close();
 
-        // update package info from bower.json
-        $bowerFile = $this->config->getInstallDir() . '/' . $package->getName() . '/bower.json';
-        if (file_exists($bowerFile)) {
-            $bowerContent = json_decode(file_get_contents($bowerFile), true);
-            $package->setInfo(array_merge($bowerContent, $package->getInfo()));
+        // merge package info with bower.json contents
+        $bowerJsonPath = $this->config->getInstallDir() . '/' . $package->getName() . '/bower.json';
+        if ($this->filesystem->exists($bowerJsonPath)) {
+            $bowerJson = $this->filesystem->read($bowerJsonPath);
+            $bower = json_decode($bowerJson, true);
+            $package->setInfo(array_merge($bower, $package->getInfo()));
         }
 
         // create .bower.json metadata file

--- a/src/Bowerphp/Installer/Installer.php
+++ b/src/Bowerphp/Installer/Installer.php
@@ -75,6 +75,13 @@ class Installer implements InstallerInterface
         }
         $this->zipArchive->close();
 
+        // update package info from bower.json
+        $bowerFile = $this->config->getInstallDir() . '/' . $package->getName() . '/bower.json';
+        if (file_exists($bowerFile)) {
+            $bowerContent = json_decode(file_get_contents($bowerFile), true);
+            $package->setInfo(array_merge($bowerContent, $package->getInfo()));
+        }
+
         // create .bower.json metadata file
          // XXX we still need to add some other info
         $dotBowerContent = array_merge($package->getInfo(), ['version' => $package->getVersion()]);


### PR DESCRIPTION
This fixes #128.

The above issue was cause by the fact that for packages installed from GitHub no package info and hence no dependencies were provided. It was fixed by updating package info (and in consequence `.bower.json` file) with the data from package's `bower.json`.