### PR TITLE
Add missing methods to Package and Repository interfaces

### DIFF
--- a/src/Bowerphp/Package/Package.php
+++ b/src/Bowerphp/Package/Package.php
@@ -100,9 +100,7 @@ class Package implements PackageInterface
     }
 
     /**
-     * Set the required packages
-     *
-     * @param array $requires A set of package links
+     * {@inheritdoc}
      */
     public function setRequires(array $requires = null)
     {
@@ -123,9 +121,7 @@ class Package implements PackageInterface
     }
 
     /**
-     * Set the info
-     *
-     * @param array $info
+     * {@inheritdoc}
      */
     public function setInfo(array $info)
     {

--- a/src/Bowerphp/Package/PackageInterface.php
+++ b/src/Bowerphp/Package/PackageInterface.php
@@ -53,11 +53,25 @@ interface PackageInterface
     public function getRequires();
 
     /**
+     * Set the required packages
+     *
+     * @param array $requires A set of package links
+     */
+    public function setRequires(array $requires = null);
+
+    /**
      * Returns all package info (e.g. info from package's bower.json)
      *
      * @return array
      */
     public function getInfo();
+
+    /**
+     * Set package info
+     *
+     * @param array $info
+     */
+    public function setInfo(array $info);
 
     /**
      * Stores a reference to the repository that owns the package

--- a/src/Bowerphp/Repository/GithubRepository.php
+++ b/src/Bowerphp/Repository/GithubRepository.php
@@ -43,7 +43,7 @@ class GithubRepository implements RepositoryInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getUrl()
     {

--- a/src/Bowerphp/Repository/RepositoryInterface.php
+++ b/src/Bowerphp/Repository/RepositoryInterface.php
@@ -20,6 +20,11 @@ interface RepositoryInterface
     public function setUrl($url, $raw = true);
 
     /**
+     * @return string
+     */
+    public function getUrl();
+
+    /**
      * @param Client $githubClient
      */
     public function setHttpClient(Client $githubClient);


### PR DESCRIPTION
This adds to `PackageInterface` and `RepositoryInterface` missing definitions of methods that are already in use.