### PR TITLE
Add console output

### DIFF
--- a/src/Bowerphp/Bowerphp.php
+++ b/src/Bowerphp/Bowerphp.php
@@ -105,6 +105,7 @@ class Bowerphp
 
         // if package is already installed, match current version with latest available version
         if ($this->isPackageInstalled($package)) {
+            $this->output->writelnInfoPackage($package, 'validate', sprintf('%s against %s#%s', $packageTag, $package->getName(), $package->getRequiredVersion()));
             $packageBower = $this->config->getPackageBowerFileContent($package);
             if ($packageTag == $packageBower['version']) {
                 // if version is fully matching, there's no need to install
@@ -112,12 +113,9 @@ class Bowerphp
             }
         }
 
-        $this->output->writelnInfoPackage($package);
-
-        $this->output->writelnInstalledPackage($package);
-
         $this->cachePackage($package);
 
+        $this->output->writelnInstalledPackage($package);
         $installer->install($package);
 
         $overrides = $this->config->getOverrideFor($package->getName());
@@ -182,6 +180,8 @@ class Bowerphp
         $package->setRequires(isset($bower['dependencies']) ? $bower['dependencies'] : null);
 
         $packageTag = $this->getPackageTag($package);
+        $this->output->writelnInfoPackage($package, 'validate', sprintf('%s against %s#%s', $packageTag, $package->getName(), $package->getRequiredVersion()));
+
         $package->setRepository($this->repository);
         if ($packageTag == $package->getVersion()) {
             // if version is fully matching, there's no need to update
@@ -189,10 +189,9 @@ class Bowerphp
         }
         $package->setVersion($packageTag);
 
-        $this->output->writelnUpdatingPackage($package);
-
         $this->cachePackage($package);
 
+        $this->output->writelnUpdatingPackage($package);
         $installer->update($package);
 
         $overrides = $this->config->getOverrideFor($package->getName());
@@ -448,6 +447,8 @@ class Bowerphp
      */
     private function cachePackage(PackageInterface $package)
     {
+        $this->output->writelnInfoPackage($package, 'download');
+
         // get release archive from repository
         $file = $this->repository->getRelease();
 

--- a/src/Bowerphp/Output/BowerphpConsoleOutput.php
+++ b/src/Bowerphp/Output/BowerphpConsoleOutput.php
@@ -31,11 +31,15 @@ class BowerphpConsoleOutput
      * writelnInfoPackage
      *
      * @param PackageInterface $package
+     * @param string           $action
+     * @param string           $message
      */
-    public function writelnInfoPackage(PackageInterface $package)
+    public function writelnInfoPackage(PackageInterface $package, $action = '', $message = '')
     {
-        $this->output->writeln(sprintf('bower <info>%s</info>',
-            str_pad($package->getName() . '#' . $package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT)
+        $this->output->writeln(sprintf('bower <info>%s</info> <fg=cyan>%s</fg=cyan> %s',
+            str_pad($package->getName() . '#' . $package->getRequiredVersion(), 21, ' ', STR_PAD_RIGHT),
+            str_pad($action, 10, ' ', STR_PAD_LEFT),
+            $message
         ));
     }
 

--- a/tests/Bowerphp/Test/BowerphpTest.php
+++ b/tests/Bowerphp/Test/BowerphpTest.php
@@ -204,6 +204,10 @@ EOT;
             ->shouldReceive('install')->never()
         ;
 
+        $this->output
+            ->shouldReceive('writelnInfoPackage')
+        ;
+
         //$this->filesystem
         //    ->shouldReceive('exists')->with(getcwd() . '/bower_components/jquery/.bower.json')->andReturn(false)
         //    ->shouldReceive('dumpFile')->with('./tmp/jquery', "fileAsString...", 0644)

--- a/tests/Bowerphp/Test/Output/BowerphpConsoleOutputTest.php
+++ b/tests/Bowerphp/Test/Output/BowerphpConsoleOutputTest.php
@@ -28,7 +28,7 @@ class BowerphpConsoleOutputTest extends \PHPUnit_Framework_TestCase
         ;
 
         $output
-            ->shouldReceive('writeln')->with('bower <info>jquery#2.1           </info>')
+            ->shouldReceive('writeln')->with('bower <info>jquery#2.1           </info> <fg=cyan>          </fg=cyan> ')
         ;
 
         $bConsoleOutput = new BowerphpConsoleOutput($output);


### PR DESCRIPTION
Related to #7.

This PR adds console output for `install` and `update` commands similar to those displayed by Bower. Currently `validate`, `download` and `install` events are logged.

Example:

```console
> bin/bowerphp install jquery#1.9 
bower jquery#1.9              validate 1.9.1 against jquery#1.9
bower jquery#1.9              download 
bower jquery#1.9.1             install

```

```console
> bin/bowerphp update jquery            
bower jquery#^1.9             validate 1.12.4 against jquery#^1.9
bower jquery#^1.9             download 
bower jquery#^1.9              install


```
